### PR TITLE
Respect transaction credit/debit

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,44 @@ python3 -m ledgertools.cli categorize \
   --out ~/Private/account_data/new.ledger
 ```
 
-This command will prompt the user with a new transaction
-and a list of all existing categories from the given ledger account.
-This allows you to quickly find existing accounts to post this transaction against.
+# What is Categorization?
 
-By default, the categories are listed by frequency which is easy but not very useful.
+Every transaction is posted to at lease two accounts.
+Usually, one of the accounts is implied by the source data.
+For example, all transactions downloaded from your checking account
+should be posted against:
+
+* an account representing you checking account (implied)
+* some other account or virtual account (e.g. Expenses:Gas or Assets:Savings)
+
+The categorization command will prompt the user with a new transaction
+and a list of all existing accounts in the given ledger account.
+This allows you to quickly find existing accounts
+to post this transaction against.
 
 ## Categorization Actions
 
+By default,
+the categories are listed by frequency which is easy but not very useful.
+We provide some additional actions to help you categorize faster:
+
 * You can type '/' to enter fuzzy search mode.
   The categories will be reordered to best match your query.
+
+# Transaction Type
+
+All source plugins must return a list of *incomplete transactions*.
+with exactly one account missing.
+The incomplete transactions must have the following fields:
+
+* `date` - `datetime.date`
+* `description` - `string`
+* `account` - `string`
+* `amount` - `int` representing cents
+* `notes` - `string`
+* `supplement` - a `list` of `(string, string)` values
+   to add context when categorizing
+
 
 # Roadmap
 

--- a/ledgertools/categorize.py
+++ b/ledgertools/categorize.py
@@ -1,6 +1,7 @@
 from functional import seq
 from collections import Counter
 from fuzzywuzzy import fuzz
+from .utils import dump_amount
 import pick
 import pickle
 import textwrap
@@ -11,10 +12,13 @@ def to_ledger_format(mint_tran, category):
     return textwrap.dedent("""\
         {date}  {description}
             ; {notes}
-            {new_category}  ${amount}
-            {account name}
+            {new_category}  {new_amount}
+            {account}  {existing_amount}
 
-        """).format(new_category=category, **mint_tran)
+        """).format(new_category=category,
+                    new_amount=dump_amount(-1 * mint_tran['amount']),
+                    existing_amount=dump_amount(mint_tran['amount']),
+                    **mint_tran)
 
 
 def run_categorization(trans_path, ledger_path, out_path):
@@ -73,13 +77,14 @@ def merge_dicts(*dict_args):
 
 def categorize(transaction, ledger_trans, progress):
     display_params = merge_dicts(transaction, progress)
+    # TODO: handle supplementary data
     title = textwrap.dedent("""\
         Transaction
         ===========
-        Description : {description} ({original description})
+        Description : {description}
         Date        : {date}
         Amount      : {amount}
-        Account     : {account name}
+        Account     : {account}
         Notes       : {notes}
         Progress    : {current} / {total}
         """).format(**display_params)

--- a/ledgertools/data_actions.py
+++ b/ledgertools/data_actions.py
@@ -1,13 +1,6 @@
 from collections import namedtuple
+from .utils import dump_amount
 from . import mint, ledger
-
-
-# def render_new_trans(mint_file, ledger_file):
-#    """Stub function for finding new mint transactions"""
-#    mint_trans = mint.filter_pending_trans(mint.get_data(mint_file))
-#    ledger_trans = ledger.read_ledger_trans(ledger_file)
-#
-#    return render(diff(mint_trans, ledger_trans))
 
 
 TransactionKey = namedtuple(
@@ -20,9 +13,7 @@ def key_mint_tran(mint_tran):
     return (
         TransactionKey(
             mint_tran['date'],
-            # Look for posting against bank account (negative posting)
-            # since categorized transactions can be split
-            '-' + mint_tran['amount'],
+            mint_tran['amount'],
             mint_tran['description']
         ),
         mint_tran
@@ -52,9 +43,14 @@ def trans_filter(ledger_trans):
 
 def find_new(mint_trans, ledger_trans):
     """Finds mint trans not yet included in a list of ledger trans"""
-    keyed_trans = map(key_mint_tran, mint_trans)
-    new_trans = filter(trans_filter(ledger_trans), keyed_trans)
+    keyed_trans = list(map(key_mint_tran, mint_trans))
+    new_trans = list(filter(trans_filter(ledger_trans), keyed_trans))
 
+    print(list(keyed_trans))
+    print('-'*80)
+    print(list(map(simplify_ledger_tran, ledger_trans)))
+    print('-'*80)
+    print(new_trans)
     return list(map(lambda x: x[1], new_trans))
 
 

--- a/ledgertools/data_actions.py
+++ b/ledgertools/data_actions.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-from .utils import dump_amount
 from . import mint, ledger
 
 

--- a/ledgertools/data_actions.py
+++ b/ledgertools/data_actions.py
@@ -46,11 +46,6 @@ def find_new(mint_trans, ledger_trans):
     keyed_trans = list(map(key_mint_tran, mint_trans))
     new_trans = list(filter(trans_filter(ledger_trans), keyed_trans))
 
-    print(list(keyed_trans))
-    print('-'*80)
-    print(list(map(simplify_ledger_tran, ledger_trans)))
-    print('-'*80)
-    print(new_trans)
     return list(map(lambda x: x[1], new_trans))
 
 

--- a/ledgertools/ledger.py
+++ b/ledgertools/ledger.py
@@ -1,4 +1,5 @@
 from subprocess import check_output
+from .utils import parse_amount
 import datetime
 from io import StringIO
 import csv
@@ -36,7 +37,7 @@ def parse_transaction(tran):
         # TODO: maybe use a named tuple with dollars and cents?
         #       better than a int of cents, since you won't forget to render
         #       later
-        'amount': lambda x: "{:0.2f}".format(float(x))
+        'amount': parse_amount
     }
     return {k: modifiers.get(k, lambda x: x)(v)
             for (k, v)

--- a/ledgertools/mint.py
+++ b/ledgertools/mint.py
@@ -24,7 +24,7 @@ def parse_transaction(tran):
         'account': tran['Account Name'],
         'amount': parse_amount(tran['Amount']) * amount_multiplier,
         'notes': tran['Notes'],
-        'supplement' : [
+        'supplement': [
             ('Original Description', tran['Original Description'])
         ]
     }

--- a/ledgertools/utils.py
+++ b/ledgertools/utils.py
@@ -1,26 +1,10 @@
+from decimal import Decimal
+
+
 def parse_amount(string_amount):
     """Convert string dollar amount to integer of cents"""
-    sign = -1 if string_amount[0] == '-' else 1
-    parts = list(map(int, string_amount.split('.')))
-
-    if '.' not in string_amount:
-        # No cents
-        value = parts[0] * 100
-    elif len(parts) == 1:
-        # No dollars
-        value = parts[0]
-    elif len(parts) == 2:
-        # Dollars and cents
-        value = (parts[0] * 100) + parts[1]
-    else:
-        raise Exception("Amount {} is poorly formatted".format(string_amount))
-
-    return value * sign
+    return Decimal(string_amount)
 
 
-def dump_amount(cents, unit='$'):
-    dollars_str = str(abs(cents))[:-2]
-    cents_str = str(abs(cents))[-2:]
-    sign = '-' if cents < 0 else ''
-
-    return sign + unit + dollars_str + '.' + cents_str
+def dump_amount(decimal, unit='$'):
+    return unit + str(decimal)

--- a/ledgertools/utils.py
+++ b/ledgertools/utils.py
@@ -1,0 +1,26 @@
+def parse_amount(string_amount):
+    """Convert string dollar amount to integer of cents"""
+    sign = -1 if string_amount[0] == '-' else 1
+    parts = list(map(int, string_amount.split('.')))
+
+    if '.' not in string_amount:
+        # No cents
+        value = parts[0] * 100
+    elif len(parts) == 1:
+        # No dollars
+        value = parts[0]
+    elif len(parts) == 2:
+        # Dollars and cents
+        value = (parts[0] * 100) + parts[1]
+    else:
+        raise Exception("Amount {} is poorly formatted".format(string_amount))
+
+    return value * sign
+
+
+def dump_amount(cents, unit='$'):
+    dollars_str = str(abs(cents))[:-2]
+    cents_str = str(abs(cents))[-2:]
+    sign = '-' if cents < 0 else ''
+
+    return sign + unit + dollars_str + '.' + cents_str

--- a/tests/data/example.ledger
+++ b/tests/data/example.ledger
@@ -6,7 +6,7 @@
 2011-04-07  Xxxxxxx Xxxxxxxxxxx Xxx
     ; None
     Expenses:Incedentals:Gotchas  $5.00
-    CREDIT CARD
+    CHECKING
 
 2011-04-08  Xxxxxx
     ; None

--- a/tests/data/new_transactions.py
+++ b/tests/data/new_transactions.py
@@ -3,51 +3,47 @@ import datetime
 
 new_transactions = [
     {
-        'account name': 'CREDIT CARD',
-        'amount': '10.00',
-        'category': 'Gas & Fuel',
+        'account': 'CREDIT CARD',
+        'amount': -1000,
         'date': datetime.date(2011, 4, 10),
         'description': 'New Tran Description',
-        'labels': '',
         'notes': '',
-        'original description': 'Orig desc',
-        'transaction type': 'debit'
+        'supplement': [
+            ('Original Description', 'Orig desc'),
+        ]
     }
 ]
 
 
 many_new_transactions = [
     {
-        'account name': 'CREDIT CARD',
-        'amount': '10.00',
-        'category': 'Gas & Fuel',
+        'account': 'CREDIT CARD',
+        'amount': -1000,
         'date': datetime.date(2011, 4, 10),
         'description': 'New Tran Description',
-        'labels': '',
         'notes': '',
-        'original description': 'Orig desc',
-        'transaction type': 'debit'
+        'supplement': [
+            ('Original Description', 'Orig desc'),
+        ]
     },
     {
-        'account name': 'CREDIT CARD',
-        'amount': '50.00',
-        'category': 'Gas & Fuel',
+        'account': 'CREDIT CARD',
+        'amount': -5000,
         'date': datetime.date(2011, 4, 10),
         'description': 'New Tran Description',
-        'labels': '',
         'notes': '',
-        'original description': 'Orig desc',
-        'transaction type': 'debit'
+        'supplement': [
+            ('Original Description', 'Orig desc'),
+        ]
     },
     {
-        'account name': 'CREDIT CARD',
-        'amount': '67.00',
-        'category': 'Gas & Fuel',
+        'account': 'CREDIT CARD',
+        'amount': -6700,
         'date': datetime.date(2011, 4, 10),
         'description': 'New Tran Description',
-        'labels': '',
         'notes': '',
-        'original description': 'Orig desc',
-        'transaction type': 'debit'
+        'supplement': [
+            ('Original Description', 'Orig desc'),
+        ]
     }
 ]

--- a/tests/data/new_transactions.py
+++ b/tests/data/new_transactions.py
@@ -1,10 +1,11 @@
+from decimal import Decimal
 import datetime
 
 
 new_transactions = [
     {
         'account': 'CREDIT CARD',
-        'amount': -1000,
+        'amount': Decimal('-10.00'),
         'date': datetime.date(2011, 4, 10),
         'description': 'New Tran Description',
         'notes': '',
@@ -18,7 +19,7 @@ new_transactions = [
 many_new_transactions = [
     {
         'account': 'CREDIT CARD',
-        'amount': -1000,
+        'amount': Decimal('-10.00'),
         'date': datetime.date(2011, 4, 10),
         'description': 'New Tran Description',
         'notes': '',
@@ -28,7 +29,7 @@ many_new_transactions = [
     },
     {
         'account': 'CREDIT CARD',
-        'amount': -5000,
+        'amount': Decimal('-50.00'),
         'date': datetime.date(2011, 4, 10),
         'description': 'New Tran Description',
         'notes': '',
@@ -38,7 +39,7 @@ many_new_transactions = [
     },
     {
         'account': 'CREDIT CARD',
-        'amount': -6700,
+        'amount': Decimal('-67.00'),
         'date': datetime.date(2011, 4, 10),
         'description': 'New Tran Description',
         'notes': '',

--- a/tests/data/parsed_ledger_data.py
+++ b/tests/data/parsed_ledger_data.py
@@ -1,9 +1,10 @@
 import datetime
+from decimal import Decimal
 
 
 parsed_ledger_data = [
     {
-        'amount': '50.57',
+        'amount': Decimal('50.57'),
         'category': 'Expenses:Food:Eating Out',
         'date': datetime.date(2011, 4, 8),
         'notes': ' None',
@@ -13,7 +14,7 @@ parsed_ledger_data = [
         'unknown': ''
     },
     {
-        'amount': '-50.57',
+        'amount': Decimal('-50.57'),
         'category': 'CREDIT CARD',
         'date': datetime.date(2011, 4, 8),
         'notes': ' None',
@@ -23,7 +24,7 @@ parsed_ledger_data = [
         'unknown': ''
     },
     {
-        'amount': '5.00',
+        'amount': Decimal('5.00'),
         'category': 'Expenses:Incedentals:Gotchas',
         'date': datetime.date(2011, 4, 7),
         'notes': ' None',
@@ -33,7 +34,7 @@ parsed_ledger_data = [
         'unknown': ''
     },
     {
-        'amount': '-5.00',
+        'amount': Decimal('-5.00'),
         'category': 'CHECKING',
         'date': datetime.date(2011, 4, 7),
         'notes': ' None',
@@ -43,7 +44,7 @@ parsed_ledger_data = [
         'unknown': ''
     },
     {
-        'amount': '60.57',
+        'amount': Decimal('60.57'),
         'category': 'Expenses:Transport:Gas',
         'date': datetime.date(2011, 4, 8),
         'notes': ' None',
@@ -53,7 +54,7 @@ parsed_ledger_data = [
         'unknown': ''
     },
     {
-        'amount': '-60.57',
+        'amount': Decimal('-60.57'),
         'category': 'CREDIT CARD',
         'date': datetime.date(2011, 4, 8),
         'notes': ' None',

--- a/tests/data/parsed_ledger_data.py
+++ b/tests/data/parsed_ledger_data.py
@@ -34,7 +34,7 @@ parsed_ledger_data = [
     },
     {
         'amount': '-5.00',
-        'category': 'CREDIT CARD',
+        'category': 'CHECKING',
         'date': datetime.date(2011, 4, 7),
         'notes': ' None',
         'payee': 'Xxxxxxx Xxxxxxxxxxx Xxx',

--- a/tests/data/pending_trans_removed.py
+++ b/tests/data/pending_trans_removed.py
@@ -3,36 +3,33 @@ import datetime
 
 pending_trans_removed = [
     {
-        'account name': 'CHECKING',
-        'amount': '5.00',
-        'category': 'Bank Fee',
+        'account': 'CHECKING',
+        'amount': -500,
         'date': datetime.date(2011, 4, 7),
         'description': 'Xxxxxxx Xxxxxxxxxxx Xxx',
-        'labels': '',
         'notes': '',
-        'original description': 'XXXXXXX XXXXXXX XXX',
-        'transaction type': 'debit'
+        'supplement': [
+            ('Original Description', 'XXXXXXX XXXXXXX XXX'),
+        ]
     },
     {
-        'account name': 'CREDIT CARD',
-        'amount': '50.57',
-        'category': 'Gas & Fuel',
+        'account': 'CREDIT CARD',
+        'amount': -5057,
         'date': datetime.date(2011, 4, 8),
         'description': 'Xxxxxx',
-        'labels': '',
         'notes': '',
-        'original description': 'XXXXXX 1231231231',
-        'transaction type': 'debit'
+        'supplement': [
+            ('Original Description', 'XXXXXX 1231231231'),
+        ]
     },
     {
-        'account name': 'CREDIT CARD',
-        'amount': '10.00',
-        'category': 'Gas & Fuel',
+        'account': 'CREDIT CARD',
+        'amount': -1000,
         'date': datetime.date(2011, 4, 10),
         'description': 'New Tran Description',
-        'labels': '',
         'notes': '',
-        'original description': 'Orig desc',
-        'transaction type': 'debit'
+        'supplement': [
+            ('Original Description', 'Orig desc'),
+        ]
     }
 ]

--- a/tests/data/pending_trans_removed.py
+++ b/tests/data/pending_trans_removed.py
@@ -1,10 +1,11 @@
+from decimal import Decimal
 import datetime
 
 
 pending_trans_removed = [
     {
         'account': 'CHECKING',
-        'amount': -500,
+        'amount': Decimal('-5.00'),
         'date': datetime.date(2011, 4, 7),
         'description': 'Xxxxxxx Xxxxxxxxxxx Xxx',
         'notes': '',
@@ -14,7 +15,7 @@ pending_trans_removed = [
     },
     {
         'account': 'CREDIT CARD',
-        'amount': -5057,
+        'amount': Decimal('-50.57'),
         'date': datetime.date(2011, 4, 8),
         'description': 'Xxxxxx',
         'notes': '',
@@ -24,7 +25,7 @@ pending_trans_removed = [
     },
     {
         'account': 'CREDIT CARD',
-        'amount': -1000,
+        'amount': Decimal('-10.00'),
         'date': datetime.date(2011, 4, 10),
         'description': 'New Tran Description',
         'notes': '',

--- a/tests/test_data_actions.py
+++ b/tests/test_data_actions.py
@@ -24,3 +24,11 @@ def test_new_trans_with_split_tran():
                                            'tests/data/split_tran.ledger')
 
     assert new == new_transactions
+
+
+def test_new_trans_with_small_amount():
+    small_mint_trans = 'tests/data/mint_transactions_small_tran.csv'
+    new = data_actions.new_trans_from_path(small_mint_trans,
+                                           'tests/data/small_tran.ledger')
+
+    assert new == new_transactions

--- a/tests/test_ledger_format.py
+++ b/tests/test_ledger_format.py
@@ -1,12 +1,13 @@
 import textwrap
 import datetime
+from decimal import Decimal
 from ledgertools.categorize import to_ledger_format
 
 
 def test_to_ledger_format():
     mint_tran = {
             'account': 'CREDIT CARD',
-            'amount': -1000,
+            'amount': Decimal('-10.00'),
             'date': datetime.date(2011, 4, 8),
             'description': 'Xxxxxx',
             'notes': 'optional notes',
@@ -19,7 +20,7 @@ def test_to_ledger_format():
         2011-04-08  Xxxxxx
             ; optional notes
             Expenses:Food:Eating Out  $10.00
-            CREDIT CARD  -$10.00
+            CREDIT CARD  $-10.00
 
         """)
 

--- a/tests/test_ledger_format.py
+++ b/tests/test_ledger_format.py
@@ -5,22 +5,21 @@ from ledgertools.categorize import to_ledger_format
 
 def test_to_ledger_format():
     mint_tran = {
-            'account name': 'CREDIT CARD',
-            'amount': '10.00',
-            'category': 'Gas & Fuel',
+            'account': 'CREDIT CARD',
+            'amount': -1000,
             'date': datetime.date(2011, 4, 8),
             'description': 'Xxxxxx',
-            'labels': '',
             'notes': 'optional notes',
-            'original description': 'Orig desc',
-            'transaction type': 'debit'
+            'supplement': [
+                ('original description', 'Orig desc'),
+            ]
         }
 
     expected = textwrap.dedent("""\
         2011-04-08  Xxxxxx
             ; optional notes
             Expenses:Food:Eating Out  $10.00
-            CREDIT CARD
+            CREDIT CARD  -$10.00
 
         """)
 

--- a/tests/test_mint.py
+++ b/tests/test_mint.py
@@ -1,6 +1,7 @@
 import pytest
 import datetime
 from ledgertools import mint
+from decimal import Decimal
 
 
 test_mint_data = 'tests/data/mint_transactions_example.csv'
@@ -21,7 +22,7 @@ def test_parse_tran():
 
     expected = {
         'account': 'CREDIT CARD',
-        'amount': -250,
+        'amount': Decimal('-2.50'),
         'date': datetime.date(2016, 10, 10),
         'description': 'Commonplace',
         'notes': '',
@@ -48,7 +49,7 @@ def test_parse_refund():
 
     expected = {
         'account': 'CREDIT CARD',
-        'amount': 250,
+        'amount': Decimal('2.50'),
         'date': datetime.date(2016, 10, 10),
         'description': 'ATM Refund',
         'notes': '',
@@ -65,7 +66,7 @@ def test_get_data():
     expected = [
         {
             'account': 'CREDIT CARD',
-            'amount': -125000,
+            'amount': Decimal('-1250.00'),
             'date': datetime.date(2016, 10, 10),
             'description': 'Example Description',
             'notes': '',
@@ -75,7 +76,7 @@ def test_get_data():
         },
         {
             'account': 'CHECKING',
-            'amount': -500,
+            'amount': Decimal('-5.00'),
             'date': datetime.date(2011, 4, 7),
             'description': 'Xxxxxxx Xxxxxxxxxxx Xxx',
             'notes': '',
@@ -85,7 +86,7 @@ def test_get_data():
         },
         {
             'account':'CREDIT CARD',
-            'amount': -5057,
+            'amount': Decimal('-50.57'),
             'date': datetime.date(2011, 4, 8),
             'description': 'Xxxxxx',
             'notes': '',

--- a/tests/test_mint.py
+++ b/tests/test_mint.py
@@ -6,13 +6,56 @@ from ledgertools import mint
 test_mint_data = 'tests/data/mint_transactions_example.csv'
 
 
-def test_parse_trans():
-    actual = mint.parse_transaction({'date': '1/01/2017',
-                                     'amount': '10.00',
-                                     'other': 'stays the same'})
-    expected = {'date': datetime.date(2017, 1, 1),
-                'amount': '10.00',
-                'other': 'stays the same'}
+def test_parse_tran():
+    actual = mint.parse_transaction({
+        'Account Name': 'CREDIT CARD',
+        'Amount': '2.50',
+        'Category': 'Coffee Shop',
+        'Date': '10/10/2016',
+        'Description': 'Commonplace',
+        'Labels': '',
+        'Notes': '',
+        'Original Description': 'COMMONPLACE COFFEE HOUSE',
+        'Transaction Type': 'debit'
+    })
+
+    expected = {
+        'account': 'CREDIT CARD',
+        'amount': -250,
+        'date': datetime.date(2016, 10, 10),
+        'description': 'Commonplace',
+        'notes': '',
+        'supplement': [
+            ('Original Description', 'COMMONPLACE COFFEE HOUSE')
+        ]
+    }
+
+    assert actual == expected
+
+
+def test_parse_refund():
+    actual = mint.parse_transaction({
+        'Account Name': 'CREDIT CARD',
+        'Amount': '2.50',
+        'Category': 'ATM Refund',
+        'Date': '10/10/2016',
+        'Description': 'ATM Refund',
+        'Labels': '',
+        'Notes': '',
+        'Original Description': 'ATM REFUND',
+        'Transaction Type': 'credit'
+    })
+
+    expected = {
+        'account': 'CREDIT CARD',
+        'amount': 250,
+        'date': datetime.date(2016, 10, 10),
+        'description': 'ATM Refund',
+        'notes': '',
+        'supplement': [
+            ('Original Description', 'ATM REFUND')
+        ]
+    }
 
     assert actual == expected
 
@@ -21,43 +64,38 @@ def test_get_data():
     actual = mint.get_data('tests/data/mint_transactions_basic.csv')
     expected = [
         {
-            'account name': 'CREDIT CARD',
-            'amount': '1250.00',
-            'category': 'Gift',
+            'account': 'CREDIT CARD',
+            'amount': -125000,
             'date': datetime.date(2016, 10, 10),
             'description': 'Example Description',
-            'labels': '',
             'notes': '',
-            'original description': 'FULL DESCRIPTION',
-            'transaction type': 'debit'
+            'supplement': [
+                ('Original Description', 'FULL DESCRIPTION'),
+            ]
         },
         {
-            'account name': 'CHECKING',
-            'amount': '5.00',
-            'category': 'Bank Fee',
+            'account': 'CHECKING',
+            'amount': -500,
             'date': datetime.date(2011, 4, 7),
             'description': 'Xxxxxxx Xxxxxxxxxxx Xxx',
-            'labels': '',
             'notes': '',
-            'original description': 'XXXXXXX XXXXXXX XXX',
-            'transaction type': 'debit'
+            'supplement': [
+                ('Original Description', 'XXXXXXX XXXXXXX XXX'),
+            ]
         },
         {
-            'account name': 'CREDIT CARD',
-            'amount': '50.57',
-            'category': 'Gas & Fuel',
+            'account':'CREDIT CARD',
+            'amount': -5057,
             'date': datetime.date(2011, 4, 8),
             'description': 'Xxxxxx',
-            'labels': '',
             'notes': '',
-            'original description': 'XXXXXX 1231231231',
-            'transaction type': 'debit'
+            'supplement': [
+                ('Original Description', 'XXXXXX 1231231231'),
+            ]
         },
     ]
 
     assert actual == expected
-
-
 def test_pending_filter():
     mint_trans = mint.get_data(test_mint_data)
     filtered = mint.filter_pending_trans(mint_trans)

--- a/tests/test_mint.py
+++ b/tests/test_mint.py
@@ -85,7 +85,7 @@ def test_get_data():
             ]
         },
         {
-            'account':'CREDIT CARD',
+            'account': 'CREDIT CARD',
             'amount': Decimal('-50.57'),
             'date': datetime.date(2011, 4, 8),
             'description': 'Xxxxxx',
@@ -97,6 +97,8 @@ def test_get_data():
     ]
 
     assert actual == expected
+
+
 def test_pending_filter():
     mint_trans = mint.get_data(test_mint_data)
     filtered = mint.filter_pending_trans(mint_trans)


### PR DESCRIPTION
Previously, all transactions were treated as expenses. This causes returns to be improperly rendered (as duplicate expenses).